### PR TITLE
Reply to functionality for bulk templated mail

### DIFF
--- a/lib/ex_aws/ses.ex
+++ b/lib/ex_aws/ses.ex
@@ -153,6 +153,7 @@ defmodule ExAws.SES do
           | {:return_path_arn, String.t()}
           | {:source, String.t()}
           | {:source_arn, String.t()}
+          | {:reply_to, [email_address]}
           | {:tags, %{(String.t() | atom) => String.t()}}
 
   @spec send_templated_email(
@@ -185,6 +186,7 @@ defmodule ExAws.SES do
           | {:return_path_arn, String.t()}
           | {:source_arn, String.t()}
           | {:default_template_data, String.t()}
+          | {:reply_to, [email_address]}
           | {:tags, %{(String.t() | atom) => String.t()}}
 
   @spec send_bulk_templated_email(
@@ -197,6 +199,7 @@ defmodule ExAws.SES do
     params =
       opts
       |> build_opts([:configuration_set_name, :return_path, :return_path_arn, :source_arn, :default_template_data])
+      |> Map.merge(format_member_attribute(:reply_to_addresses, opts[:reply_to]))
       |> Map.merge(format_tags(opts[:tags]))
       |> Map.merge(format_bulk_destinations(destinations))
       |> Map.put("DefaultTemplateData", format_template_data(opts[:default_template_data]) )

--- a/test/lib/ses_test.exs
+++ b/test/lib/ses_test.exs
@@ -207,6 +207,7 @@ defmodule ExAws.SESTest do
         "Destinations.member.2.ReplacementTemplateData" => Poison.encode!(replacement_template_data2),
         "Destinations.member.3.Destination.ToAddresses.member.1" => "email8@email.com",
         "DefaultTemplateData" => Poison.encode!(default_template_data),
+        "ReplyToAddresses.member.1" => "user@example.com", "ReplyToAddresses.member.2" => "user1@example.com",
         "ReturnPath" => "feedback@example.com",
         "ReturnPathArn" => "arn:aws:ses:us-east-1:123456789012:identity/example.com",
         "SourceArn" => "east-1:123456789012:identity/example.com",


### PR DESCRIPTION
Added reply_to option to send_bulk_templated_email, and changed the function specs of send_bulk_templated_email and send_templated_email to accept reply_to option. Tests for send_bulk_templated_email reflect this added functionality.