### PR TITLE
Add functions for custom verification emails

### DIFF
--- a/lib/ex_aws/ses.ex
+++ b/lib/ex_aws/ses.ex
@@ -551,6 +551,87 @@ defmodule ExAws.SES do
     )
   end
 
+  @doc "Create a custom verification email template."
+  @spec create_custom_verification_email_template(
+          String.t(),
+          String.t(),
+          String.t(),
+          String.t(),
+          String.t(),
+          String.t()
+        ) :: ExAws.Operation.Query.t()
+  def create_custom_verification_email_template(
+        template_name,
+        from_email_address,
+        template_subject,
+        template_content,
+        success_redirection_url,
+        failure_redirection_url
+      ) do
+    request(:create_custom_verification_email_template, %{
+      "TemplateName" => template_name,
+      "FromEmailAddress" => from_email_address,
+      "TemplateSubject" => template_subject,
+      "TemplateContent" => template_content,
+      "SuccessRedirectionURL" => success_redirection_url,
+      "FailureRedirectionURL" => failure_redirection_url
+    })
+  end
+
+  @type update_custom_verification_email_template_opt ::
+          {:template_name, String.t()}
+          | {:from_email_address, String.t()}
+          | {:template_subject, String.t()}
+          | {:template_content, String.t()}
+          | {:success_redirection_url, String.t()}
+          | {:failure_redirection_url, String.t()}
+  @doc "Update or create a custom verification email template."
+  @spec update_custom_verification_email_template(opts :: [update_custom_verification_email_template_opt] | []) ::
+          ExAws.Operation.Query.t()
+  def update_custom_verification_email_template(opts \\ []) do
+    params =
+      opts
+      |> build_opts([
+        :template_name,
+        :from_email_address,
+        :template_subject,
+        :template_content
+      ])
+      |> maybe_put_param(opts, :success_redirection_url, "SuccessRedirectionURL")
+      |> maybe_put_param(opts, :failure_redirection_url, "FailureRedirectionURL")
+
+    request(:update_custom_verification_email_template, params)
+  end
+
+  @doc "Delete custom verification email template."
+  @spec delete_custom_verification_email_template(String.t()) :: ExAws.Operation.Query.t()
+  def delete_custom_verification_email_template(template_name) do
+    request(:delete_custom_verification_email_template, %{"TemplateName" => template_name})
+  end
+
+  @type list_custom_verification_email_templates_opt :: {:max_results, String.t()} | {:next_token, String.t()}
+  @doc "Lists custom verification email templates."
+  @spec list_custom_verification_email_templates(opts :: [list_custom_verification_email_templates_opt()] | []) ::
+          ExAws.Operation.Query.t()
+  def list_custom_verification_email_templates(opts \\ []) do
+    params = build_opts(opts, [:max_results, :next_token])
+    request(:list_custom_verification_email_templates, params)
+  end
+
+  @type send_custom_verification_email_opt :: {:configuration_set_name, String.t()}
+  @doc "Send a verification email using a custom template."
+  @spec send_custom_verification_email(String.t(), String.t(), opts :: [send_custom_verification_email_opt] | []) ::
+          ExAws.Operation.Query.t()
+  def send_custom_verification_email(email_address, template_name, opts \\ []) do
+    params =
+      opts
+      |> build_opts([:configuration_set_name])
+      |> Map.put("EmailAddress", email_address)
+      |> Map.put("TemplateName", template_name)
+
+    request(:send_custom_verification_email, params)
+  end
+
   defp format_dst(dst, root \\ "destination") do
     dst =
       Enum.reduce([:to, :bcc, :cc], %{}, fn key, acc ->
@@ -636,6 +717,13 @@ defmodule ExAws.SES do
     |> Map.new()
     |> Map.take(permitted)
     |> camelize_keys
+  end
+
+  defp maybe_put_param(params, opts, key, name) do
+    case opts[key] do
+      nil -> params
+      value -> Map.put(params, name, value)
+    end
   end
 
   defp format_member_attributes(opts, members) do

--- a/lib/ex_aws/ses/parsers.ex
+++ b/lib/ex_aws/ses/parsers.ex
@@ -26,12 +26,21 @@ if Code.ensure_loaded?(SweetXml) do
       {:ok, Map.put(resp, :body, parsed_body)}
     end
 
-    def parse({:ok, %{body: xml}=resp}, :list_configuration_sets) do
-      parsed_body = xml
-      |> SweetXml.xpath(~x"//ListConfigurationSetsResponse",
-                        configuration_sets: [
-                          ~x"./ListConfigurationSetsResult",
-                            members: ~x"./ConfigurationSets/member/Name/text()"ls,
+    def parse({:ok, %{body: xml} = resp}, :list_identities) do
+      parsed_body =
+        xml
+        |> SweetXml.xpath(~x"//ListIdentitiesResponse",
+          custom_verification_email_templates: [
+            ~x"./ListIdentitiesResult",
+            members: ~x"./Identities/member/text()"ls,
+            next_token: ~x"./NextToken/text()"so
+          ],
+          request_id: request_id_xpath()
+        )
+
+      {:ok, Map.put(resp, :body, parsed_body)}
+    end
+
                             next_token: ~x"./NextToken/text()"so,
                           ],
                           request_id: request_id_xpath()
@@ -111,6 +120,29 @@ if Code.ensure_loaded?(SweetXml) do
 
     def parse({:ok, %{body: xml} = resp}, :delete_template) do
       parsed_body = SweetXml.xpath(xml, ~x"//DeleteTemplateResponse", request_id: request_id_xpath())
+
+      {:ok, Map.put(resp, :body, parsed_body)}
+    end
+
+    def parse({:ok, %{body: xml} = resp}, :list_custom_verification_email_templates) do
+      parsed_body =
+        xml
+        |> SweetXml.xpath(~x"//ListCustomVerificationEmailTemplatesResponse",
+          custom_verification_email_templates: [
+            ~x"./ListCustomVerificationEmailTemplatesResult",
+            members: [
+              ~x"./CustomVerificationEmailTemplates/member"l,
+              template_name: ~x"./TemplateName/text()",
+              from_email_address: ~x"./FromEmailAddress/text()",
+              template_subject: ~x"./TemplateSubject/text()",
+              template_content: ~x"./TemplateContent/text()",
+              success_redirection_url: ~x"./SuccessRedirectionURL/text()",
+              failure_redirection_url: ~x"./FailureRedirectionURL/text()"
+            ],
+            next_token: ~x"./NextToken/text()"so
+          ],
+          request_id: request_id_xpath()
+        )
 
       {:ok, Map.put(resp, :body, parsed_body)}
     end

--- a/lib/ex_aws/ses/parsers.ex
+++ b/lib/ex_aws/ses/parsers.ex
@@ -41,10 +41,17 @@ if Code.ensure_loaded?(SweetXml) do
       {:ok, Map.put(resp, :body, parsed_body)}
     end
 
-                            next_token: ~x"./NextToken/text()"so,
-                          ],
-                          request_id: request_id_xpath()
-      )
+    def parse({:ok, %{body: xml} = resp}, :list_configuration_sets) do
+      parsed_body =
+        xml
+        |> SweetXml.xpath(~x"//ListConfigurationSetsResponse",
+          configuration_sets: [
+            ~x"./ListConfigurationSetsResult",
+            members: ~x"./ConfigurationSets/member/Name/text()"ls,
+            next_token: ~x"./NextToken/text()"so
+          ],
+          request_id: request_id_xpath()
+        )
 
       {:ok, Map.put(resp, :body, parsed_body)}
     end
@@ -132,12 +139,11 @@ if Code.ensure_loaded?(SweetXml) do
             ~x"./ListCustomVerificationEmailTemplatesResult",
             members: [
               ~x"./CustomVerificationEmailTemplates/member"l,
-              template_name: ~x"./TemplateName/text()",
-              from_email_address: ~x"./FromEmailAddress/text()",
-              template_subject: ~x"./TemplateSubject/text()",
-              template_content: ~x"./TemplateContent/text()",
-              success_redirection_url: ~x"./SuccessRedirectionURL/text()",
-              failure_redirection_url: ~x"./FailureRedirectionURL/text()"
+              template_name: ~x"./TemplateName/text()"so,
+              from_email_address: ~x"./FromEmailAddress/text()"so,
+              template_subject: ~x"./TemplateSubject/text()"so,
+              success_redirection_url: ~x"./SuccessRedirectionURL/text()"so,
+              failure_redirection_url: ~x"./FailureRedirectionURL/text()"so
             ],
             next_token: ~x"./NextToken/text()"so
           ],

--- a/test/lib/ses/parser_test.exs
+++ b/test/lib/ses/parser_test.exs
@@ -265,6 +265,72 @@ defmodule ExAws.SES.ParserTest do
     assert parsed_doc == %{request_id: "12345abcd-c666-111e-88aa-cc8899bb1177"}
   end
 
+  test "#parse list_identities" do
+    rsp = """
+      <ListIdentitiesResponse xmlns=\"http://ses.amazonaws.com/doc/2010-12-01/\">
+        <ListIdentitiesResult>
+          <Identities>
+            <member>user@example.com</member>
+            <member>user2@example.com</member>
+          </Identities>
+        </ListIdentitiesResult>
+        <ResponseMetadata>
+          <RequestId>12345abcd-c666-111e-88aa-cc8899bb1177</RequestId>
+        </ResponseMetadata>
+      </ListIdentitiesResponse>
+    """
+    |> to_success
+
+    {:ok, %{body: parsed_doc}} = Parsers.parse(rsp, :list_identities)
+
+    assert parsed_doc == %{
+      request_id: "12345abcd-c666-111e-88aa-cc8899bb1177",
+      custom_verification_email_templates: %{
+        members: ["user@example.com", "user2@example.com"],
+        next_token: ""
+      }
+    }
+  end
+
+  test "#parse list_custom_verification_email_templates" do
+    rsp = """
+    <ListCustomVerificationEmailTemplatesResponse xmlns=\"http://ses.amazonaws.com/doc/2010-12-01/\">
+      <ListCustomVerificationEmailTemplatesResult>
+        <CustomVerificationEmailTemplates>
+          <member>
+            <TemplateSubject>Subject</TemplateSubject>
+            <FailureRedirectionURL>https://example.com/failure</FailureRedirectionURL>
+            <SuccessRedirectionURL>https://example.com/success</SuccessRedirectionURL>
+            <FromEmailAddress>user@example.com</FromEmailAddress>
+            <TemplateName>Template Name</TemplateName>
+          </member>
+        </CustomVerificationEmailTemplates>
+      </ListCustomVerificationEmailTemplatesResult>
+      <ResponseMetadata>
+        <RequestId>12345abcd-c666-111e-88aa-cc8899bb1177</RequestId>
+      </ResponseMetadata>
+    </ListCustomVerificationEmailTemplatesResponse>
+    """
+    |> to_success()
+
+    {:ok, %{body: parsed_doc}} = Parsers.parse(rsp, :list_custom_verification_email_templates)
+    assert parsed_doc == %{
+      request_id: "12345abcd-c666-111e-88aa-cc8899bb1177",
+      custom_verification_email_templates: %{
+        members: [
+          %{
+            template_name: "Template Name",
+            template_subject: "Subject",
+            failure_redirection_url: "https://example.com/failure",
+            success_redirection_url: "https://example.com/success",
+            from_email_address: "user@example.com"
+          }
+        ],
+        next_token: ""
+      }
+    }
+  end
+
   test "#parse error" do
     rsp = """
       <ErrorResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/">

--- a/test/lib/ses_test.exs
+++ b/test/lib/ses_test.exs
@@ -668,4 +668,91 @@ defmodule ExAws.SESTest do
 
     assert expected == SES.delete_template(templateName).params
   end
+
+  test "#create custom email verification template" do
+    template_name = "MyTemplate"
+    from_email_address = "test@example.com"
+    template_subject = "Verified with ExAWS!"
+    template_content = "This is some custom content"
+    success_redirection_url = "https://example.com/success"
+    failure_redirection_url = "https://example.com/failure"
+
+    expected = %{
+      "Action" => "CreateCustomVerificationEmailTemplate",
+      "TemplateName" => template_name,
+      "FromEmailAddress" => from_email_address,
+      "TemplateSubject" => template_subject,
+      "TemplateContent" => template_content,
+      "SuccessRedirectionURL" => success_redirection_url,
+      "FailureRedirectionURL" => failure_redirection_url
+    }
+
+    assert expected == SES.create_custom_verification_email_template(template_name, from_email_address, template_subject, template_content, success_redirection_url, failure_redirection_url).params
+  end
+
+  test "#update custom email verification template" do
+    template_name = "MyTemplate"
+    from_email_address = "test@example.com"
+    template_subject = "Verified with ExAWS!"
+    template_content = "This is some custom content"
+    success_redirection_url = "https://example.com/success"
+    failure_redirection_url = "https://example.com/failure"
+
+    expected = %{
+      "Action" => "UpdateCustomVerificationEmailTemplate",
+      "TemplateName" => template_name,
+      "FromEmailAddress" => from_email_address,
+      "TemplateSubject" => template_subject,
+      "TemplateContent" => template_content,
+      "SuccessRedirectionURL" => success_redirection_url,
+      "FailureRedirectionURL" => failure_redirection_url
+    }
+
+    assert expected == SES.update_custom_verification_email_template(
+      template_name: template_name,
+      from_email_address: from_email_address,
+      template_subject: template_subject,
+      template_content: template_content,
+      success_redirection_url: success_redirection_url,
+      failure_redirection_url: failure_redirection_url).params
+  end
+
+  test "#delete custom email verification template" do
+    template_name = "MyTemplate"
+
+    expected = %{
+      "Action" => "DeleteCustomVerificationEmailTemplate",
+      "TemplateName" => template_name
+    }
+
+    assert expected == SES.delete_custom_verification_email_template(template_name).params
+  end
+
+  test "#list custom verification email templates" do
+    max_results = 25
+    next_token = "token"
+
+    expected = %{
+      "Action" => "ListCustomVerificationEmailTemplates",
+      "MaxResults" => max_results,
+      "NextToken" => next_token
+    }
+
+    assert expected == SES.list_custom_verification_email_templates(max_results: max_results, next_token: next_token).params
+  end
+
+  test "#send verification email with custom template" do
+    template_name = "MyTemplate"
+      email_address = "test@example.com"
+      configuration_set_name = "MyConfigurationSet"
+
+      expected = %{
+        "Action" => "SendCustomVerificationEmail",
+        "TemplateName" => template_name,
+        "EmailAddress" => email_address,
+        "ConfigurationSetName" => configuration_set_name
+      }
+
+      assert expected == SES.send_custom_verification_email(email_address, template_name, configuration_set_name: configuration_set_name).params
+  end
 end


### PR DESCRIPTION
This implements the following new functions:

- `create_custom_verification_email_template/6`
- `update_custom_verification_email_template/1`
- `delete_custom_verification_email_template/1`
- `list_custom_verification_email_templates/1`
- `send_custom_verification_email/3`

It includes a parser for `list_custom_verification_email_templates` and adds a parser for the existing function `list_identities`.