### PR TITLE
Feature/manipulate suppressed destinations

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/ex_aws/ses.ex
+++ b/lib/ex_aws/ses.ex
@@ -26,6 +26,7 @@ defmodule ExAws.SES do
 
   @type tag :: %{Key: String.t(), Value: String.t()}
   @type list_topic :: %{String.t() => String.t()}
+  @type suppression_reason :: :BOUNCE | :COMPLAINT
 
   @doc "List identities associated with the AWS account"
   @spec list_identities(opts :: [] | [list_identities_opt]) :: ExAws.Operation.Query.t()
@@ -260,6 +261,29 @@ defmodule ExAws.SES do
 
     request_v2(:post, "import-jobs")
     |> Map.put(:data, data)
+  end
+
+  ## Suppression Lists
+  ######################
+  @doc """
+  Add an email address to list of suppressed destinations. A suppression reason
+  is mandatory (see `t:suppression_reason()`).
+  """
+  @spec put_suppressed_destination(String.t(), SuppressionReason.t()) :: ExAws.Operation.JSON.t()
+  def put_suppressed_destination(email_address, suppression_reason) do
+    request_v2(:put, "suppression/addresses")
+    |> Map.put(:data, %{
+      EmailAddress: email_address,
+      Reason: suppression_reason
+    })
+  end
+
+  @doc """
+  Delete an email address from list of suppressed destinations.
+  """
+  @spec delete_suppressed_destination(String.t()) :: ExAws.Operation.JSON.t()
+  def delete_suppressed_destination(email_address) do
+    request_v2(:delete, "suppression/addresses/#{email_address}")
   end
 
   ## Templates

--- a/test/lib/ses_test.exs
+++ b/test/lib/ses_test.exs
@@ -199,6 +199,30 @@ defmodule ExAws.SESTest do
     end
   end
 
+  describe "suppressed destinations" do
+    test "#put_suppressed_destination" do
+      email = "test@example.com"
+      operation = SES.put_suppressed_destination(email, :BOUNCE)
+
+      expected_data = %{
+        EmailAddress: email,
+        Reason: :BOUNCE
+      }
+
+      assert operation.http_method == :put
+      assert operation.path == "/v2/email/suppression/addresses"
+      assert operation.data == expected_data
+    end
+
+    test "#delete_suppressed_destination" do
+      email = "test@example.com"
+      operation = SES.delete_suppressed_destination(email)
+
+      assert operation.http_method == :delete
+      assert operation.path == "/v2/email/suppression/addresses/#{email}"
+    end
+  end
+
   describe "v2 API send_email" do
     test "simple html", context do
       content = %{

--- a/test/lib/ses_test.exs
+++ b/test/lib/ses_test.exs
@@ -108,8 +108,7 @@ defmodule ExAws.SESTest do
       source = %{DataFormat: "CSV", S3Url: "s3://test_bucket/test_object.csv"}
       destination = %{ContactListDestination: %{ContactListImportAction: "PUT", ContactListName: @list_name}}
 
-      expected_data =
-        data = %{
+      expected_data = %{
           ImportDataSource: source,
           ImportDestination: destination
         }


### PR DESCRIPTION
Adds two operations for manipulating the suppressed destinations list:

- https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_PutSuppressedDestination.html as `put_suppressed_destination/2`
- https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_DeleteSuppressedDestination.html as `delete_suppressed_destination/1`