### PR TITLE
Encode email address in URL

### DIFF
--- a/lib/ex_aws/ses.ex
+++ b/lib/ex_aws/ses.ex
@@ -205,7 +205,9 @@ defmodule ExAws.SES do
         "UnsubscribeAll" => opts[:unsubscribe_all]
       })
 
-    request_v2(:put, "contact-lists/#{list_name}/contacts/#{email}")
+    uri_encoded_email = ExAws.Request.Url.uri_encode(email)
+
+    request_v2(:put, "contact-lists/#{list_name}/contacts/#{uri_encoded_email}")
     |> Map.put(:data, data)
   end
 
@@ -222,7 +224,8 @@ defmodule ExAws.SES do
   """
   @spec get_contact(String.t(), email_address) :: ExAws.Operation.JSON.t()
   def get_contact(list_name, email) do
-    request_v2(:get, "contact-lists/#{list_name}/contacts/#{email}")
+    uri_encoded_email = ExAws.Request.Url.uri_encode(email)
+    request_v2(:get, "contact-lists/#{list_name}/contacts/#{uri_encoded_email}")
   end
 
   @doc """
@@ -230,7 +233,8 @@ defmodule ExAws.SES do
   """
   @spec delete_contact(String.t(), email_address) :: ExAws.Operation.JSON.t()
   def delete_contact(list_name, email) do
-    request_v2(:delete, "contact-lists/#{list_name}/contacts/#{email}")
+    uri_encoded_email = ExAws.Request.Url.uri_encode(email)
+    request_v2(:delete, "contact-lists/#{list_name}/contacts/#{uri_encoded_email}")
   end
 
   @doc """
@@ -283,7 +287,9 @@ defmodule ExAws.SES do
   """
   @spec delete_suppressed_destination(String.t()) :: ExAws.Operation.JSON.t()
   def delete_suppressed_destination(email_address) do
-    request_v2(:delete, "suppression/addresses/#{email_address}")
+    uri_encoded_email_address = ExAws.Request.Url.uri_encode(email_address)
+
+    request_v2(:delete, "suppression/addresses/#{uri_encoded_email_address}")
   end
 
   ## Templates

--- a/test/lib/ses_test.exs
+++ b/test/lib/ses_test.exs
@@ -171,7 +171,7 @@ defmodule ExAws.SESTest do
         )
 
       assert operation.http_method == :put
-      assert operation.path == "/v2/email/contact-lists/#{@list_name}/contacts/#{ExAws.Request.Url.uri_encode(email)}"
+      assert operation.path == "/v2/email/contact-lists/#{@list_name}/contacts/test%2Bbar%40example.com"
       assert operation.data == expected_data
     end
 
@@ -187,7 +187,7 @@ defmodule ExAws.SESTest do
       operation = SES.get_contact(@list_name, email)
 
       assert operation.http_method == :get
-      assert operation.path == "/v2/email/contact-lists/#{@list_name}/contacts/#{ExAws.Request.Url.uri_encode(email)}"
+      assert operation.path == "/v2/email/contact-lists/#{@list_name}/contacts/test%2Bbar%40example.com"
     end
 
     test "#delete_contact" do
@@ -195,7 +195,7 @@ defmodule ExAws.SESTest do
       operation = SES.delete_contact(@list_name, email)
 
       assert operation.http_method == :delete
-      assert operation.path == "/v2/email/contact-lists/#{@list_name}/contacts/#{ExAws.Request.Url.uri_encode(email)}"
+      assert operation.path == "/v2/email/contact-lists/#{@list_name}/contacts/test%2Bbar%40example.com"
     end
   end
 
@@ -215,11 +215,11 @@ defmodule ExAws.SESTest do
     end
 
     test "#delete_suppressed_destination" do
-      email = "test+stuff@example.com"
+      email = "test+bar@example.com"
       operation = SES.delete_suppressed_destination(email)
 
       assert operation.http_method == :delete
-      assert operation.path == "/v2/email/suppression/addresses/#{ExAws.Request.Url.uri_encode(email)}"
+      assert operation.path == "/v2/email/suppression/addresses/test%2Bbar%40example.com"
     end
   end
 

--- a/test/lib/ses_test.exs
+++ b/test/lib/ses_test.exs
@@ -109,9 +109,9 @@ defmodule ExAws.SESTest do
       destination = %{ContactListDestination: %{ContactListImportAction: "PUT", ContactListName: @list_name}}
 
       expected_data = %{
-          ImportDataSource: source,
-          ImportDestination: destination
-        }
+        ImportDataSource: source,
+        ImportDestination: destination
+      }
 
       operation = SES.create_import_job(source, destination)
 
@@ -150,7 +150,7 @@ defmodule ExAws.SESTest do
     end
 
     test "#update_contact" do
-      email = "test@example.com"
+      email = "test+bar@example.com"
       topic = %{TopicName: "test_topic", SubscriptionStatus: "OPT_IN"}
       attributes = "test attribute"
       unsubscribe = false
@@ -171,7 +171,7 @@ defmodule ExAws.SESTest do
         )
 
       assert operation.http_method == :put
-      assert operation.path == "/v2/email/contact-lists/#{@list_name}/contacts/#{email}"
+      assert operation.path == "/v2/email/contact-lists/#{@list_name}/contacts/#{ExAws.Request.Url.uri_encode(email)}"
       assert operation.data == expected_data
     end
 
@@ -183,19 +183,19 @@ defmodule ExAws.SESTest do
     end
 
     test "#get_contact" do
-      email = "test@example.com"
+      email = "test+bar@example.com"
       operation = SES.get_contact(@list_name, email)
 
       assert operation.http_method == :get
-      assert operation.path == "/v2/email/contact-lists/#{@list_name}/contacts/#{email}"
+      assert operation.path == "/v2/email/contact-lists/#{@list_name}/contacts/#{ExAws.Request.Url.uri_encode(email)}"
     end
 
     test "#delete_contact" do
-      email = "test@example.com"
+      email = "test+bar@example.com"
       operation = SES.delete_contact(@list_name, email)
 
       assert operation.http_method == :delete
-      assert operation.path == "/v2/email/contact-lists/#{@list_name}/contacts/#{email}"
+      assert operation.path == "/v2/email/contact-lists/#{@list_name}/contacts/#{ExAws.Request.Url.uri_encode(email)}"
     end
   end
 
@@ -215,11 +215,11 @@ defmodule ExAws.SESTest do
     end
 
     test "#delete_suppressed_destination" do
-      email = "test@example.com"
+      email = "test+stuff@example.com"
       operation = SES.delete_suppressed_destination(email)
 
       assert operation.http_method == :delete
-      assert operation.path == "/v2/email/suppression/addresses/#{email}"
+      assert operation.path == "/v2/email/suppression/addresses/#{ExAws.Request.Url.uri_encode(email)}"
     end
   end
 


### PR DESCRIPTION
ExAws replaces `+` [with spaces](https://github.com/ex-aws/ex_aws/blob/3b866892290dee742ab059a34f8bd158369901e9/lib/ex_aws/request/url.ex#L73) in the request path. 

This is problematic whenever we construct an URL that contains an email, such as when deleting a suppressed destination that contains pluses (`me+something@gmail.com`), since the signatures will mismatch (but also since for email addresses pluses are not substitutable with spaces like for normal URLs):

This affects the recently added `put_suppressed_destination` but also other existing funs that interpolate an email address into the request URL:

```elixir
iex(5)> ExAws.SES.update_contact("some_list", "foo+bar@email.com") |> ExAws.request()
[debug] ExAws: Request URL: "https://email.eu-central-1.amazonaws.com/v2/email/contact-lists/some_list/contacts/foo%20bar@email.com" HEADERS: [{"Authorization", "AWS4-HMAC-SHA256 Credential=<REDACTED>/20220322/eu-central-1/ses/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=<REDACTED>"}, {"host", "email.eu-central-1.amazonaws.com"}, {"x-amz-date", "20220322T135136Z"}, {"x-amz-content-sha256", ""}] BODY: "{}" ATTEMPT: 1
{:error,
 {:http_error, 403,
  %{
    body: "{\"message\":\"The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.\"}",
    headers: [
      {"Date", "Tue, 22 Mar 2022 13:51:36 GMT"},
      {"Content-Type", "application/json"},
      {"Content-Length", "192"},
      {"Connection", "keep-alive"},
      {"x-amzn-RequestId", "baf6932a-c379-425f-a5c4-8ea284fca7c2"},
      {"x-amzn-ErrorType", "InvalidSignatureException"}
    ],
    status_code: 403
  }}}
```

This PR addresses this issue by using ExAws's `uri_encode` function whenever we interpolate an email into a API URL.